### PR TITLE
add missing shebang to zookeeper.initd

### DIFF
--- a/apache-zookeeper/zookeeper.initd
+++ b/apache-zookeeper/zookeeper.initd
@@ -1,3 +1,4 @@
+#! /bin/bash
 
 # description: Starts and stops zookeeper
 # update deamon path to point to the zookeeper executable

--- a/environments/aws/oracle-jdk.sh
+++ b/environments/aws/oracle-jdk.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export SCRIPT_ROOT="/tmp/cassy-up"
+
+chmod a+x $SCRIPT_ROOT/oracle-jdk/main.sh
+
+(cd $SCRIPT_ROOT/oracle-jdk && ./main.sh)


### PR DESCRIPTION
The zookeeper.initd script was missing a shebang, without zookeeper doesn't start on Ubuntu.