### PR TITLE
remove kafka_ and zookeeper_ prefixes from terraform modules.

### DIFF
--- a/terraform/kafka/kafka_ebs.tf
+++ b/terraform/kafka/kafka_ebs.tf
@@ -1,15 +1,15 @@
 resource "aws_ebs_volume" "kafka-ebs" {
-  count = "${var.kafka_count}"
+  count = "${var.count}"
   availability_zone = "${element(aws_instance.kafka.*.availability_zone, count.index)}"
-  size = "${var.kafka_ebs_size_per_node}"
-  type = "${var.kafka_ebs_type}"
+  size = "${var.ebs_size_per_node}"
+  type = "${var.ebs_type}"
   tags {
-    Name = "${format("%s-ebs-%d", var.kafka_tag_name, count.index + 1)}"
+    Name = "${format("%s-ebs-%d", var.tag_name, count.index + 1)}"
   }
 }
 
 resource "aws_volume_attachment" "kafka-ebs-attach" {
-  count = "${var.kafka_count}"
+  count = "${var.count}"
   device_name = "/dev/xvdh"
   volume_id = "${element(aws_ebs_volume.kafka-ebs.*.id, count.index)}"
   instance_id = "${element(aws_instance.kafka.*.id, count.index)}"

--- a/terraform/kafka/variables.tf
+++ b/terraform/kafka/variables.tf
@@ -1,19 +1,19 @@
-variable kafka_rev {}
+variable rev {}
 
-variable kafka_count {}
-variable kafka_tag_name {}
+variable count {}
+variable tag_name {}
 
-variable kafka_ebs_size_per_node {}
-variable kafka_ebs_type {}
+variable ebs_size_per_node {}
+variable ebs_type {}
 
-variable kafka_ami_id {}
-variable kafka_iam_instance_profile {}
-variable kafka_instance_type {}
-variable kafka_sg_ids {}
-variable kafka_subnet_ids {}
+variable ami_id {}
+variable iam_instance_profile {}
+variable instance_type {}
+variable sg_ids {}
+variable subnet_ids {}
 
-variable kafka_ssh_user {}
-variable kafka_ssh_identity_file {}
+variable ssh_user {}
+variable ssh_identity_file {}
 
-variable kafka_provisioning_scripts {}
-variable kafka_zk_ips {}
+variable provisioning_scripts {}
+variable zk_ips {}

--- a/terraform/zookeeper/main.tf
+++ b/terraform/zookeeper/main.tf
@@ -1,28 +1,28 @@
 resource "aws_instance" "zookeeper" {
-    count = "${var.zookeeper_count}"
-    ami = "${var.zookeeper_ami_id}"
+    count = "${var.count}"
+    ami = "${var.ami_id}"
     key_name = "datalake"
-    instance_type = "${var.zookeeper_instance_type}"
-    iam_instance_profile = "${var.zookeeper_iam_instance_profile}"
-    subnet_id = "${element(split(",", var.zookeeper_subnet_ids), count.index % length(split(",", var.zookeeper_subnet_ids)))}"
-    vpc_security_group_ids = ["${split(",", var.zookeeper_sg_ids)}"]
+    instance_type = "${var.instance_type}"
+    iam_instance_profile = "${var.iam_instance_profile}"
+    subnet_id = "${element(split(",", var.subnet_ids), count.index % length(split(",", var.subnet_ids)))}"
+    vpc_security_group_ids = ["${split(",", var.sg_ids)}"]
     tags = {
-      Name = "${format("%s-%d", var.zookeeper_tag_name, count.index + 1)}"
+      Name = "${format("%s-%d", var.tag_name, count.index + 1)}"
     }
 }
 
 resource "null_resource" "provision-zookeeper" {
-  count = "${var.zookeeper_count}"
+  count = "${var.count}"
 
   triggers {
-    revision = "${var.zookeeper_rev}"
+    revision = "${var.rev}"
   }
 
   connection {
-    user = "${var.zookeeper_ssh_user}"
+    user = "${var.ssh_user}"
     host = "${element(aws_instance.zookeeper.*.private_ip, count.index)}"
     agent = true
-    private_key = "${file("${var.zookeeper_ssh_identity_file}")}"
+    private_key = "${file("${var.ssh_identity_file}")}"
   }
 
   provisioner "remote-exec" {
@@ -36,22 +36,22 @@ resource "null_resource" "provision-zookeeper" {
   }
 
   provisioner "file" {
-    source = "${var.zookeeper_provisioning_scripts}/oracle-jdk"
+    source = "${var.provisioning_scripts}/oracle-jdk"
     destination = "/tmp/cassy-up"
   }
 
   provisioner "file" {
-    source = "${var.zookeeper_provisioning_scripts}/environments/aws/oracle-jdk.sh"
+    source = "${var.provisioning_scripts}/environments/aws/oracle-jdk.sh"
     destination = "/tmp/cassy-up/oracle-jdk.sh"
   }
 
   provisioner "file" {
-    source = "${var.zookeeper_provisioning_scripts}/apache-zookeeper"
+    source = "${var.provisioning_scripts}/apache-zookeeper"
     destination = "/tmp/cassy-up"
   }
 
   provisioner "file" {
-    source = "${var.zookeeper_provisioning_scripts}/environments/aws/zookeeper.sh"
+    source = "${var.provisioning_scripts}/environments/aws/zookeeper.sh"
     destination = "/tmp/cassy-up/zookeeper.sh"
   }
 
@@ -72,7 +72,7 @@ resource "null_resource" "provision-zookeeper" {
       "#!/bin/bash",
       "source /tmp/cassy-up/zookeeper_params.sh",
       "source /tmp/cassy-up/apache-zookeeper/zookeeper-params.sh",
-      "echo \"revision: ${var.zookeeper_rev}\" | sudo tee /opt/zookeeper/install.yaml",
+      "echo \"revision: ${var.rev}\" | sudo tee /opt/zookeeper/install.yaml",
       "echo \"zk:\" | sudo tee --append /opt/zookeeper/install.yaml",
       "echo \"  id: $ZOOKEEPER_MY_ID\" | sudo tee --append /opt/zookeeper/install.yaml",
       "echo \"  version: $ZOOKEEPER_VERSION\" | sudo tee --append /opt/zookeeper/install.yaml",

--- a/terraform/zookeeper/variables.tf
+++ b/terraform/zookeeper/variables.tf
@@ -1,14 +1,14 @@
-variable zookeeper_rev {}
+variable rev {}
 
-variable zookeeper_count {}
-variable zookeeper_tag_name {}
+variable count {}
+variable tag_name {}
 
-variable zookeeper_ami_id {}
-variable zookeeper_instance_type {}
-variable zookeeper_iam_instance_profile {}
-variable zookeeper_subnet_ids {}
-variable zookeeper_sg_ids {}
+variable ami_id {}
+variable instance_type {}
+variable iam_instance_profile {}
+variable subnet_ids {}
+variable sg_ids {}
 
-variable zookeeper_provisioning_scripts {}
-variable zookeeper_ssh_user {}
-variable zookeeper_ssh_identity_file {}
+variable provisioning_scripts {}
+variable ssh_user {}
+variable ssh_identity_file {}


### PR DESCRIPTION
Removing `kafka_` and `zookeeper_` prefixes from variable names as they seem redundant.