### PR TITLE
use lists instead of encoding them in strings.

### DIFF
--- a/terraform/zookeeper/main.tf
+++ b/terraform/zookeeper/main.tf
@@ -4,8 +4,8 @@ resource "aws_instance" "zookeeper" {
     key_name = "datalake"
     instance_type = "${var.instance_type}"
     iam_instance_profile = "${var.iam_instance_profile}"
-    subnet_id = "${element(split(",", var.subnet_ids), count.index % length(split(",", var.subnet_ids)))}"
-    vpc_security_group_ids = ["${split(",", var.sg_ids)}"]
+    subnet_id = "${element(var.subnet_ids, count.index % length(var.subnet_ids))}"
+    vpc_security_group_ids = [ "${var.sg_ids}" ]
     tags = {
       Name = "${format("%s-%d", var.tag_name, count.index + 1)}"
     }

--- a/terraform/zookeeper/variables.tf
+++ b/terraform/zookeeper/variables.tf
@@ -6,8 +6,12 @@ variable tag_name {}
 variable ami_id {}
 variable instance_type {}
 variable iam_instance_profile {}
-variable subnet_ids {}
-variable sg_ids {}
+variable subnet_ids {
+	type = "list"
+}
+variable sg_ids {
+	type = "list"
+}
 
 variable provisioning_scripts {}
 variable ssh_user {}


### PR DESCRIPTION
Using lists in the zookeeper module.